### PR TITLE
fix: handle varying month lengths in expense stats

### DIFF
--- a/src/lib/expenses.ts
+++ b/src/lib/expenses.ts
@@ -287,13 +287,15 @@ export async function getExpenseStats(): Promise<{ stats: any; error: any }> {
     }
 
     // Total do mês atual
-    const currentMonth = new Date().toISOString().slice(0, 7); // YYYY-MM
+    const now = new Date();
+    const currentMonth = now.toISOString().slice(0, 7); // YYYY-MM
+    const lastDayOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
     const { data: monthlyTotal, error: monthlyError } = await supabase
       .from('expenses')
       .select('amount')
       .eq('user_id', user.id)
       .gte('date', `${currentMonth}-01`)
-      .lte('date', `${currentMonth}-31`);
+      .lte('date', `${currentMonth}-${lastDayOfMonth.toString().padStart(2, '0')}`);
 
     if (monthlyError) {
       return { stats: null, error: monthlyError };


### PR DESCRIPTION
## Summary
- use actual last day of month when aggregating expenses

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688d697f44fc832f9d10a840a5eb21c2