### PR TITLE
Enable guest mode for open access

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -395,7 +395,7 @@ export default function DashboardPage() {
       await signOut();
       // Limpar cache ao fazer logout
       cache.clear();
-      router.push('/auth/login');
+      router.push('/dashboard');
     } catch (error) {
       console.error('Erro ao fazer logout:', error);
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,8 +10,11 @@ export default function HomePage() {
           <h1 className="text-4xl font-bold text-gray-900 mb-4">
             FinanceAnchor
           </h1>
-          <p className="text-gray-600 mb-8">
+          <p className="text-gray-600 mb-4">
             Seu pulso financeiro diário
+          </p>
+          <p className="text-sm text-blue-600 mb-8">
+            Acesso aberto: explore sem precisar fazer login.
           </p>
           
           {/* Teste de cores do Tailwind */}
@@ -29,16 +32,10 @@ export default function HomePage() {
           
           <div className="space-y-4">
             <Link
-              href="/auth/login"
+              href="/dashboard"
               className="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-4 rounded-lg transition-colors block"
             >
-              Entrar
-            </Link>
-            <Link
-              href="/auth/signup"
-              className="w-full bg-gray-600 hover:bg-gray-700 text-white font-bold py-3 px-4 rounded-lg transition-colors block"
-            >
-              Criar Conta
+              Explorar agora
             </Link>
           </div>
         </div>

--- a/src/app/settings/export/page.tsx
+++ b/src/app/settings/export/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { useAuth } from '@/lib/auth';
+import { isGuestUser, useAuth } from '@/lib/auth';
 import { 
   ArrowLeftIcon, 
   DocumentArrowDownIcon,
@@ -13,11 +13,16 @@ import {
 export default function ExportPage() {
   const router = useRouter();
   const { user } = useAuth();
+  const isGuest = isGuestUser(user);
   const [isExporting, setIsExporting] = useState(false);
   const [exportType, setExportType] = useState<string>('');
 
   const handleExport = async (type: 'json' | 'excel' | 'pdf') => {
     if (!user) return;
+    if (isGuest) {
+      alert('Modo visitante: exportação desativada.');
+      return;
+    }
     
     setIsExporting(true);
     setExportType(type);
@@ -70,6 +75,11 @@ export default function ExportPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
+      {isGuest && (
+        <div className="bg-blue-50 border-b border-blue-100 text-blue-700 text-sm px-4 py-3 text-center">
+          Você está em modo visitante. A exportação está desativada.
+        </div>
+      )}
       {/* Header */}
       <div className="bg-white shadow-sm border-b">
         <div className="max-w-4xl mx-auto px-4 py-4">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { useAuth } from '@/lib/auth';
+import { isGuestUser, useAuth } from '@/lib/auth';
 import { Cog6ToothIcon, UserIcon } from '@heroicons/react/24/outline';
 
 export default function Header() {
@@ -10,10 +10,11 @@ export default function Header() {
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
   const router = useRouter();
   const { user, signOut } = useAuth();
+  const isGuest = isGuestUser(user);
 
   const handleSignOut = async () => {
     await signOut();
-    router.push('/auth/login');
+    router.push('/dashboard');
   };
 
   return (
@@ -69,12 +70,17 @@ export default function Header() {
                     <UserIcon className="w-4 h-4 text-blue-600" />
                   </div>
                   <span className="hidden md:block text-sm text-gray-700">
-                    {user.email}
+                    {isGuest ? 'Visitante' : user.email}
                   </span>
                 </button>
 
                 {isUserMenuOpen && (
                   <div className="absolute right-0 mt-2 w-48 bg-white rounded-lg shadow-lg border border-gray-200 py-2 z-50">
+                    {isGuest && (
+                      <div className="px-4 py-2 text-xs text-blue-600">
+                        Modo visitante
+                      </div>
+                    )}
                     <button
                       onClick={() => {
                         router.push('/settings');

--- a/src/lib/achievements.ts
+++ b/src/lib/achievements.ts
@@ -1,4 +1,5 @@
 import { supabase } from './supabase';
+import { getCurrentUser, isGuestUser } from './auth';
 import { Achievement, AchievementType, AchievementConfig, AchievementProgress } from '../types/achievement';
 import { Expense } from '../types/expense';
 import { Goal } from '../types/goal';
@@ -95,8 +96,10 @@ export const ACHIEVEMENT_CONFIGS: Record<AchievementType, AchievementConfig> = {
 // Função para obter conquistas do usuário
 export async function getUserAchievements(): Promise<Achievement[]> {
   try {
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) throw new Error('Usuário não autenticado');
+    const { user } = await getCurrentUser();
+    if (!user || isGuestUser(user)) {
+      return [];
+    }
 
     const { data, error } = await supabase
       .from('achievements')
@@ -115,8 +118,8 @@ export async function getUserAchievements(): Promise<Achievement[]> {
 // Função para verificar se usuário já tem uma conquista
 export async function hasAchievement(type: AchievementType): Promise<boolean> {
   try {
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return false;
+    const { user } = await getCurrentUser();
+    if (!user || isGuestUser(user)) return false;
 
     const { data, error } = await supabase
       .from('achievements')
@@ -140,8 +143,8 @@ export async function addAchievement(
   description: string
 ): Promise<boolean> {
   try {
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) throw new Error('Usuário não autenticado');
+    const { user } = await getCurrentUser();
+    if (!user || isGuestUser(user)) return false;
 
     // Verifica se já tem a conquista
     const alreadyHas = await hasAchievement(type);

--- a/src/lib/budgets.ts
+++ b/src/lib/budgets.ts
@@ -1,13 +1,18 @@
 import { supabase } from './supabase';
+import { getCurrentUser, isGuestUser } from './auth';
 import { Budget, CreateBudgetData, UpdateBudgetData, BudgetStatus, BudgetSummary } from '@/types/budget';
 
 // Criar novo orçamento
 export async function createBudget(budgetData: CreateBudgetData): Promise<{ budget: Budget | null; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { budget: null, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return { budget: null, error: { message: 'Modo visitante: criação desabilitada' } };
     }
 
     // Se não especificado, usar mês atual
@@ -39,10 +44,14 @@ export async function createBudget(budgetData: CreateBudgetData): Promise<{ budg
 // Buscar orçamentos do usuário
 export async function getUserBudgets(month?: string): Promise<{ budgets: Budget[] | null; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { budgets: null, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return { budgets: [], error: null };
     }
 
     const targetMonth = month || new Date().toISOString().slice(0, 7);
@@ -69,10 +78,14 @@ export async function getUserBudgets(month?: string): Promise<{ budgets: Budget[
 // Buscar status do orçamento (usando função SQL)
 export async function getBudgetStatus(month?: string): Promise<{ budgetStatus: BudgetStatus[] | null; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { budgetStatus: null, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return { budgetStatus: [], error: null };
     }
 
     const targetMonth = month || new Date().toISOString().slice(0, 7);
@@ -98,10 +111,22 @@ export async function getBudgetStatus(month?: string): Promise<{ budgetStatus: B
 // Buscar resumo do orçamento total
 export async function getBudgetSummary(month?: string): Promise<{ budgetSummary: BudgetSummary | null; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { budgetSummary: null, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return {
+        budgetSummary: {
+          total_budget: 0,
+          total_spent: 0,
+          percentage_used: 0,
+          status_color: 'green'
+        },
+        error: null
+      };
     }
 
     const targetMonth = month || new Date().toISOString().slice(0, 7);
@@ -135,10 +160,14 @@ export async function getBudgetSummary(month?: string): Promise<{ budgetSummary:
 // Atualizar orçamento
 export async function updateBudget(id: string, updates: UpdateBudgetData): Promise<{ budget: Budget | null; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { budget: null, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return { budget: null, error: { message: 'Modo visitante: edição desabilitada' } };
     }
 
     const { data: budget, error } = await supabase
@@ -164,10 +193,14 @@ export async function updateBudget(id: string, updates: UpdateBudgetData): Promi
 // Deletar orçamento
 export async function deleteBudget(id: string): Promise<{ success: boolean; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { success: false, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return { success: false, error: { message: 'Modo visitante: exclusão desabilitada' } };
     }
 
     const { error } = await supabase
@@ -191,10 +224,14 @@ export async function deleteBudget(id: string): Promise<{ success: boolean; erro
 // Buscar orçamento por ID
 export async function getBudgetById(id: string): Promise<{ budget: Budget | null; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { budget: null, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return { budget: null, error: null };
     }
 
     const { data: budget, error } = await supabase
@@ -219,10 +256,14 @@ export async function getBudgetById(id: string): Promise<{ budget: Budget | null
 // Buscar orçamento por categoria e mês
 export async function getBudgetByCategory(category: string, month?: string): Promise<{ budget: Budget | null; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { budget: null, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return { budget: null, error: null };
     }
 
     const targetMonth = month || new Date().toISOString().slice(0, 7);

--- a/src/lib/goals.ts
+++ b/src/lib/goals.ts
@@ -3,15 +3,20 @@
 // =====================================================
 
 import { supabase } from './supabase';
+import { getCurrentUser, isGuestUser } from './auth';
 import { Goal, CreateGoalData, UpdateGoalData, GoalSummary } from '@/types/goal';
 
 // Criar nova meta
 export async function createGoal(goalData: CreateGoalData): Promise<{ goal: Goal | null; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { goal: null, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return { goal: null, error: { message: 'Modo visitante: criação desabilitada' } };
     }
 
     const { data: goal, error } = await supabase
@@ -39,10 +44,14 @@ export async function createGoal(goalData: CreateGoalData): Promise<{ goal: Goal
 // Buscar resumo da meta principal
 export async function getGoalSummary(): Promise<{ goalSummary: GoalSummary | null; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { goalSummary: null, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return { goalSummary: null, error: null };
     }
 
     const { data, error } = await supabase
@@ -68,10 +77,14 @@ export async function getGoalSummary(): Promise<{ goalSummary: GoalSummary | nul
 // Buscar todas as metas do usuário
 export async function getUserGoals(): Promise<{ goals: Goal[] | null; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { goals: null, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return { goals: [], error: null };
     }
 
     const { data, error } = await supabase
@@ -94,10 +107,14 @@ export async function getUserGoals(): Promise<{ goals: Goal[] | null; error: any
 // Buscar meta por ID
 export async function getGoalById(id: string): Promise<{ goal: Goal | null; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { goal: null, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return { goal: null, error: null };
     }
 
     const { data: goal, error } = await supabase
@@ -122,10 +139,14 @@ export async function getGoalById(id: string): Promise<{ goal: Goal | null; erro
 // Atualizar meta
 export async function updateGoal(id: string, updates: UpdateGoalData): Promise<{ goal: Goal | null; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { goal: null, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return { goal: null, error: { message: 'Modo visitante: edição desabilitada' } };
     }
 
     const { data: goal, error } = await supabase
@@ -151,10 +172,14 @@ export async function updateGoal(id: string, updates: UpdateGoalData): Promise<{
 // Deletar meta
 export async function deleteGoal(id: string): Promise<{ success: boolean; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { success: false, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return { success: false, error: { message: 'Modo visitante: exclusão desabilitada' } };
     }
 
     const { error } = await supabase
@@ -178,10 +203,14 @@ export async function deleteGoal(id: string): Promise<{ success: boolean; error:
 // Upload de imagem para meta
 export async function uploadGoalImage(file: File): Promise<{ url: string | null; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { url: null, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return { url: null, error: { message: 'Modo visitante: upload desabilitado' } };
     }
 
     const fileExt = file.name.split('.').pop();
@@ -214,10 +243,14 @@ export async function uploadGoalImage(file: File): Promise<{ url: string | null;
 // Atualizar valor atual da meta
 export async function updateGoalProgress(id: string, newAmount: number): Promise<{ goal: Goal | null; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { goal: null, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return { goal: null, error: { message: 'Modo visitante: atualização desabilitada' } };
     }
 
     // Buscar meta atual para validar

--- a/src/lib/insights.ts
+++ b/src/lib/insights.ts
@@ -3,15 +3,29 @@
 // =====================================================
 
 import { supabase } from './supabase';
+import { getCurrentUser, isGuestUser } from './auth';
 import { DailyInsight, TodayInsight, UserInsight } from '@/types/insight';
 
 // Obter insight do dia atual (gera automaticamente se não existir)
 export async function getTodayInsight(): Promise<{ insight: TodayInsight | null; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { insight: null, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return {
+        insight: {
+          id: 'guest-insight',
+          user_id: user.id,
+          message: 'Explore livremente: seu pulso financeiro começa aqui. 💡',
+          date: new Date().toISOString().split('T')[0],
+          created_at: new Date().toISOString()
+        },
+        error: null
+      };
     }
 
     // Primeiro, verificar se já existe insight para hoje
@@ -117,10 +131,14 @@ export async function getTodayInsight(): Promise<{ insight: TodayInsight | null;
 // Obter insights dos últimos dias
 export async function getUserInsights(days: number = 7): Promise<{ insights: UserInsight[] | null; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { insights: null, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return { insights: [], error: null };
     }
 
     const { data, error } = await supabase
@@ -144,10 +162,23 @@ export async function getUserInsights(days: number = 7): Promise<{ insights: Use
 // Gerar insight manualmente
 export async function generateInsight(): Promise<{ insight: TodayInsight | null; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { insight: null, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return {
+        insight: {
+          id: 'guest-insight-generated',
+          user_id: user.id,
+          message: 'Modo visitante: ideias financeiras sem precisar de login. ✨',
+          date: new Date().toISOString().split('T')[0],
+          created_at: new Date().toISOString()
+        },
+        error: null
+      };
     }
 
     const { data, error } = await supabase
@@ -184,10 +215,14 @@ export async function generateInsight(): Promise<{ insight: TodayInsight | null;
 // Criar insight manualmente
 export async function createInsight(message: string): Promise<{ insight: DailyInsight | null; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { insight: null, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return { insight: null, error: { message: 'Modo visitante: criação desabilitada' } };
     }
 
     const { data: insight, error } = await supabase
@@ -215,10 +250,14 @@ export async function createInsight(message: string): Promise<{ insight: DailyIn
 // Deletar insight
 export async function deleteInsight(id: string): Promise<{ success: boolean; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { success: false, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return { success: false, error: { message: 'Modo visitante: exclusão desabilitada' } };
     }
 
     const { error } = await supabase
@@ -242,10 +281,14 @@ export async function deleteInsight(id: string): Promise<{ success: boolean; err
 // Buscar insight por ID
 export async function getInsightById(id: string): Promise<{ insight: DailyInsight | null; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { insight: null, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return { insight: null, error: null };
     }
 
     const { data: insight, error } = await supabase
@@ -270,10 +313,21 @@ export async function getInsightById(id: string): Promise<{ insight: DailyInsigh
 // Buscar estatísticas de insights
 export async function getInsightStats(): Promise<{ stats: any; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { stats: null, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return {
+        stats: {
+          totalInsights: 0,
+          thisWeekInsights: 0,
+          thisMonthInsights: 0
+        },
+        error: null
+      };
     }
 
     const { data: insights, error } = await supabase
@@ -312,10 +366,14 @@ export async function getInsightStats(): Promise<{ stats: any; error: any }> {
 // Verificar se já existe insight para hoje
 export async function hasTodayInsight(): Promise<{ hasInsight: boolean; error: any }> {
   try {
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    const { user, error: authError } = await getCurrentUser();
     
     if (authError || !user) {
       return { hasInsight: false, error: { message: 'Usuário não autenticado' } };
+    }
+
+    if (isGuestUser(user)) {
+      return { hasInsight: false, error: null };
     }
 
     const { data, error } = await supabase


### PR DESCRIPTION
### Motivation
- Permitir que a aplicação seja explorada sem exigir login, oferecendo uma experiência "visitante" segura e informativa para novos usuários.
- Evitar erros e redirecionamentos indesejados quando não há sessão ativa, fornecendo retornos padrão em camadas de dados.

### Description
- Adicionado `GUEST_USER_ID`, `guestUser` e `isGuestUser` em `src/lib/auth.ts` e alterado `getCurrentUser` / `useAuth` para usar esse usuário quando não houver sessão; `signOut` e o hook `useAuth` passaram a tratar o modo visitante corretamente.
- Atualizadas bibliotecas de domínio (`expenses`, `budgets`, `debts`, `goals`, `insights`, `partners`, `achievements`, `preferences`) para obter o usuário via `getCurrentUser` e aplicar `isGuestUser` para devolver valores seguros (listas vazias/resumos neutros) ou bloquear operações mutáveis no modo visitante.
- UI/UX: alterada a home para CTA "Explorar agora" (`src/app/page.tsx`), exibido rótulo "Visitante" no `Header` (`src/components/Header.tsx`) e adicionadas mensagens/limitações nas páginas de `Settings` e `Export` indicando que algumas ações estão desativadas para visitantes.
- Pequenas mudanças de navegação: após `signOut` redireciona para o `dashboard` em vez de `auth/login` para melhor fluxo do modo aberto.

### Testing
- Inicializado o servidor de desenvolvimento com `npm run dev`, Next compilou e o servidor ficou pronto (log do Next.js indicando `Ready`). — Sucesso.
- Navegação automatizada via Playwright acessou `http://127.0.0.1:3000` e gerou um screenshot (`artifacts/home-open.png`) confirmando a página inicial com CTA de exploração. — Sucesso.
- Build/compilação em dev exibiu `GET / 200` no log durante validação manual via navegador automatizado. — Sucesso.
- Não foram executados testes unitários automatizados adicionais.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fd22a66f8832f956d37cb8bc7285c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication/user resolution and many data-access paths; main risk is unintended guest behavior (writes slipping through or incorrect default data) impacting UX and data integrity.
> 
> **Overview**
> **Adds a first-class “guest mode” to allow open access without login.** `getCurrentUser`/`useAuth` now fall back to a `guestUser` (with `GUEST_USER_ID`) and `isGuestUser` gates behavior; `signOut` becomes a no-op for guests.
> 
> Core domain modules (`expenses`, `budgets`, `debts`, `goals`, `insights`, `partners`, `achievements`, `preferences`) are updated to use `getCurrentUser` and return safe defaults (empty lists/zeroed summaries) or block mutating operations when the user is a guest.
> 
> UI flows are adjusted for open access: home CTA now routes to `/dashboard`, logout redirects to `/dashboard`, the `Header` labels guests as “Visitante”, and `Settings`/`Export` show guest banners and disable restricted actions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 627390183018f4fea863fbf17230c09b457774c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->